### PR TITLE
Fix boundary lang columns

### DIFF
--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -9,8 +9,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "name_engli",
-      "lang:es_LA": "name_spani"
+      "lang:en": "name_engli",
+      "lang:es": "name_spani"
     }
   },
   {
@@ -23,7 +23,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     }
   },
   {
@@ -36,8 +36,8 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name_es",
-      "lang:en_US": "name_en"
+      "lang:es": "name_es",
+      "lang:en": "name_en"
     }
   },
   {
@@ -54,7 +54,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:cal",
@@ -75,7 +75,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:ama",
@@ -96,7 +96,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:met",
@@ -117,7 +117,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:cun",
@@ -138,7 +138,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:tol",
@@ -159,7 +159,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:ant",
@@ -180,7 +180,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:atl",
@@ -201,7 +201,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:bol",
@@ -222,7 +222,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:ces",
@@ -243,7 +243,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:mag",
@@ -264,7 +264,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:suc",
@@ -285,7 +285,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:cor",
@@ -306,7 +306,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:lag",
@@ -327,7 +327,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:cho",
@@ -348,7 +348,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:vac",
@@ -369,7 +369,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:nsa",
@@ -390,7 +390,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:qui",
@@ -411,7 +411,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:vid",
@@ -432,7 +432,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:vau",
@@ -453,7 +453,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:san",
@@ -474,7 +474,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:ris",
@@ -495,7 +495,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:put",
@@ -516,7 +516,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:nar",
@@ -537,7 +537,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:guv",
@@ -558,7 +558,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:gua",
@@ -579,7 +579,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/distrito-capital:dc",
@@ -600,7 +600,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:ara",
@@ -621,7 +621,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:boy",
@@ -642,7 +642,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:cas",
@@ -663,7 +663,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:cau",
@@ -684,7 +684,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:caq",
@@ -705,7 +705,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:hui",
@@ -726,7 +726,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:sap",
@@ -747,7 +747,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:atl/city:baranquilla",
@@ -768,7 +768,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:vac/city:cali",
@@ -789,7 +789,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:ant/city:medellin",
@@ -810,7 +810,7 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name"
+      "lang:es": "name"
     },
     "filter": {
       "match": "country:co/departamento:bol/city:cartagena",
@@ -827,8 +827,8 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name_es",
-      "lang:en_US": "name_en"
+      "lang:es": "name_es",
+      "lang:en": "name_en"
 
     }
   },
@@ -842,8 +842,8 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name_es",
-      "lang:en_US": "name_en"
+      "lang:es": "name_es",
+      "lang:en": "name_en"
     }
   },
   {
@@ -856,8 +856,8 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name_es",
-      "lang:en_US": "name_en"
+      "lang:es": "name_es",
+      "lang:en": "name_en"
     }
   },
   {
@@ -870,8 +870,8 @@
       }
     ],
     "name_columns": {
-      "lang:es_LA": "name_es",
-      "lang:en_US": "name_en"
+      "lang:es": "name_es",
+      "lang:en": "name_en"
     }
   }
 ]

--- a/executive/Q51716350/current/popolo-m17n.json
+++ b/executive/Q51716350/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Antioquia"
+        "lang:es": "Antioquia"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716353/current/popolo-m17n.json
+++ b/executive/Q51716353/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Boyacá"
+        "lang:es": "Boyacá"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716355/current/popolo-m17n.json
+++ b/executive/Q51716355/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Casanare"
+        "lang:es": "Casanare"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716357/current/popolo-m17n.json
+++ b/executive/Q51716357/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Caquetá"
+        "lang:es": "Caquetá"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716360/current/popolo-m17n.json
+++ b/executive/Q51716360/current/popolo-m17n.json
@@ -73,7 +73,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Valle del Cauca"
+        "lang:es": "Valle del Cauca"
       },
       "parent_id": "Q739"
     },
@@ -97,8 +97,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716362/current/popolo-m17n.json
+++ b/executive/Q51716362/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Risaralda"
+        "lang:es": "Risaralda"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716363/current/popolo-m17n.json
+++ b/executive/Q51716363/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Quindío"
+        "lang:es": "Quindío"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716367/current/popolo-m17n.json
+++ b/executive/Q51716367/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Magdalena"
+        "lang:es": "Magdalena"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716368/current/popolo-m17n.json
+++ b/executive/Q51716368/current/popolo-m17n.json
@@ -73,7 +73,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Nariño"
+        "lang:es": "Nariño"
       },
       "parent_id": "Q739"
     },
@@ -97,8 +97,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716371/current/popolo-m17n.json
+++ b/executive/Q51716371/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Arauca"
+        "lang:es": "Arauca"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716374/current/popolo-m17n.json
+++ b/executive/Q51716374/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Chocó"
+        "lang:es": "Chocó"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716377/current/popolo-m17n.json
+++ b/executive/Q51716377/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Bolívar"
+        "lang:es": "Bolívar"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716383/current/popolo-m17n.json
+++ b/executive/Q51716383/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cauca"
+        "lang:es": "Cauca"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716386/current/popolo-m17n.json
+++ b/executive/Q51716386/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Caldas"
+        "lang:es": "Caldas"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716389/current/popolo-m17n.json
+++ b/executive/Q51716389/current/popolo-m17n.json
@@ -70,7 +70,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Atlántico"
+        "lang:es": "Atlántico"
       },
       "parent_id": "Q739"
     },
@@ -94,8 +94,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716391/current/popolo-m17n.json
+++ b/executive/Q51716391/current/popolo-m17n.json
@@ -59,7 +59,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cundinamarca"
+        "lang:es": "Cundinamarca"
       },
       "parent_id": "Q739"
     },
@@ -83,8 +83,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716395/current/popolo-m17n.json
+++ b/executive/Q51716395/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Putumayo"
+        "lang:es": "Putumayo"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716403/current/popolo-m17n.json
+++ b/executive/Q51716403/current/popolo-m17n.json
@@ -73,7 +73,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Norte de Santander"
+        "lang:es": "Norte de Santander"
       },
       "parent_id": "Q739"
     },
@@ -97,8 +97,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716406/current/popolo-m17n.json
+++ b/executive/Q51716406/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Tolima"
+        "lang:es": "Tolima"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716410/current/popolo-m17n.json
+++ b/executive/Q51716410/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Vaupés"
+        "lang:es": "Vaupés"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716416/current/popolo-m17n.json
+++ b/executive/Q51716416/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Córdoba"
+        "lang:es": "Córdoba"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716421/current/popolo-m17n.json
+++ b/executive/Q51716421/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cesar"
+        "lang:es": "Cesar"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716425/current/popolo-m17n.json
+++ b/executive/Q51716425/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Huila"
+        "lang:es": "Huila"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716432/current/popolo-m17n.json
+++ b/executive/Q51716432/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Santander"
+        "lang:es": "Santander"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716437/current/popolo-m17n.json
+++ b/executive/Q51716437/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Sucre"
+        "lang:es": "Sucre"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716441/current/popolo-m17n.json
+++ b/executive/Q51716441/current/popolo-m17n.json
@@ -58,7 +58,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Meta"
+        "lang:es": "Meta"
       },
       "parent_id": "Q739"
     },
@@ -82,8 +82,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716447/current/popolo-m17n.json
+++ b/executive/Q51716447/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Guainía"
+        "lang:es": "Guainía"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716449/current/popolo-m17n.json
+++ b/executive/Q51716449/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Archipiélago de San Andrés, Providencia y Santa Catalina"
+        "lang:es": "Archipiélago de San Andrés, Providencia y Santa Catalina"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716452/current/popolo-m17n.json
+++ b/executive/Q51716452/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Vichada"
+        "lang:es": "Vichada"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716456/current/popolo-m17n.json
+++ b/executive/Q51716456/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "La Guajira"
+        "lang:es": "La Guajira"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716459/current/popolo-m17n.json
+++ b/executive/Q51716459/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Guaviare"
+        "lang:es": "Guaviare"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716462/current/popolo-m17n.json
+++ b/executive/Q51716462/current/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Amazonas"
+        "lang:es": "Amazonas"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716465/current/popolo-m17n.json
+++ b/executive/Q51716465/current/popolo-m17n.json
@@ -89,7 +89,7 @@
         "lang:en": "capital district or territory"
       },
       "name": {
-        "lang:es_LA": "Bogotá Distrito Capital"
+        "lang:es": "Bogotá Distrito Capital"
       },
       "parent_id": "Q739"
     },
@@ -113,8 +113,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716468/current/popolo-m17n.json
+++ b/executive/Q51716468/current/popolo-m17n.json
@@ -59,7 +59,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Valle del Cauca"
+        "lang:es": "Valle del Cauca"
       },
       "parent_id": "Q739"
     },
@@ -84,7 +84,7 @@
         "lang:en": "municipality of Colombia"
       },
       "name": {
-        "lang:es_LA": "Santiago de Cali"
+        "lang:es": "Santiago de Cali"
       },
       "parent_id": "Q13990"
     },
@@ -108,8 +108,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716472/current/popolo-m17n.json
+++ b/executive/Q51716472/current/popolo-m17n.json
@@ -59,7 +59,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Antioquia"
+        "lang:es": "Antioquia"
       },
       "parent_id": "Q739"
     },
@@ -84,7 +84,7 @@
         "lang:en": "municipality of Colombia"
       },
       "name": {
-        "lang:es_LA": "Medellín"
+        "lang:es": "Medellín"
       },
       "parent_id": "Q123304"
     },
@@ -108,8 +108,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716476/current/popolo-m17n.json
+++ b/executive/Q51716476/current/popolo-m17n.json
@@ -70,7 +70,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Atlántico"
+        "lang:es": "Atlántico"
       },
       "parent_id": "Q739"
     },
@@ -95,7 +95,7 @@
         "lang:en": "municipality of Colombia"
       },
       "name": {
-        "lang:es_LA": "Barranquilla"
+        "lang:es": "Barranquilla"
       },
       "parent_id": "Q230882"
     },
@@ -119,8 +119,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q51716481/current/popolo-m17n.json
+++ b/executive/Q51716481/current/popolo-m17n.json
@@ -56,7 +56,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Bolívar"
+        "lang:es": "Bolívar"
       },
       "parent_id": "Q739"
     },
@@ -81,7 +81,7 @@
         "lang:en": "municipality of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cartagena de Indias"
+        "lang:es": "Cartagena de Indias"
       },
       "parent_id": "Q230597"
     },
@@ -105,8 +105,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/executive/Q5419800/current/popolo-m17n.json
+++ b/executive/Q5419800/current/popolo-m17n.json
@@ -90,8 +90,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q1571756/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q1571756/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -512,7 +512,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Boyacá"
+        "lang:es": "Boyacá"
       },
       "parent_id": "Q739"
     },
@@ -535,7 +535,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Antioquia"
+        "lang:es": "Antioquia"
       },
       "parent_id": "Q739"
     },
@@ -558,7 +558,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Casanare"
+        "lang:es": "Casanare"
       },
       "parent_id": "Q739"
     },
@@ -581,7 +581,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Caquetá"
+        "lang:es": "Caquetá"
       },
       "parent_id": "Q739"
     },
@@ -604,7 +604,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Valle del Cauca"
+        "lang:es": "Valle del Cauca"
       },
       "parent_id": "Q739"
     },
@@ -627,7 +627,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Risaralda"
+        "lang:es": "Risaralda"
       },
       "parent_id": "Q739"
     },
@@ -650,7 +650,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Quindío"
+        "lang:es": "Quindío"
       },
       "parent_id": "Q739"
     },
@@ -673,7 +673,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Magdalena"
+        "lang:es": "Magdalena"
       },
       "parent_id": "Q739"
     },
@@ -696,7 +696,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Nariño"
+        "lang:es": "Nariño"
       },
       "parent_id": "Q739"
     },
@@ -719,7 +719,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Arauca"
+        "lang:es": "Arauca"
       },
       "parent_id": "Q739"
     },
@@ -742,7 +742,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Chocó"
+        "lang:es": "Chocó"
       },
       "parent_id": "Q739"
     },
@@ -765,7 +765,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Bolívar"
+        "lang:es": "Bolívar"
       },
       "parent_id": "Q739"
     },
@@ -788,7 +788,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cauca"
+        "lang:es": "Cauca"
       },
       "parent_id": "Q739"
     },
@@ -811,7 +811,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Caldas"
+        "lang:es": "Caldas"
       },
       "parent_id": "Q739"
     },
@@ -834,7 +834,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Atlántico"
+        "lang:es": "Atlántico"
       },
       "parent_id": "Q739"
     },
@@ -857,7 +857,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cundinamarca"
+        "lang:es": "Cundinamarca"
       },
       "parent_id": "Q739"
     },
@@ -880,7 +880,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Putumayo"
+        "lang:es": "Putumayo"
       },
       "parent_id": "Q739"
     },
@@ -903,7 +903,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Norte de Santander"
+        "lang:es": "Norte de Santander"
       },
       "parent_id": "Q739"
     },
@@ -926,7 +926,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Tolima"
+        "lang:es": "Tolima"
       },
       "parent_id": "Q739"
     },
@@ -949,7 +949,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Vaupés"
+        "lang:es": "Vaupés"
       },
       "parent_id": "Q739"
     },
@@ -972,7 +972,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Córdoba"
+        "lang:es": "Córdoba"
       },
       "parent_id": "Q739"
     },
@@ -995,7 +995,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cesar"
+        "lang:es": "Cesar"
       },
       "parent_id": "Q739"
     },
@@ -1018,7 +1018,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Huila"
+        "lang:es": "Huila"
       },
       "parent_id": "Q739"
     },
@@ -1041,7 +1041,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Santander"
+        "lang:es": "Santander"
       },
       "parent_id": "Q739"
     },
@@ -1064,7 +1064,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Sucre"
+        "lang:es": "Sucre"
       },
       "parent_id": "Q739"
     },
@@ -1087,7 +1087,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Meta"
+        "lang:es": "Meta"
       },
       "parent_id": "Q739"
     },
@@ -1110,7 +1110,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Guainía"
+        "lang:es": "Guainía"
       },
       "parent_id": "Q739"
     },
@@ -1133,7 +1133,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Archipiélago de San Andrés, Providencia y Santa Catalina"
+        "lang:es": "Archipiélago de San Andrés, Providencia y Santa Catalina"
       },
       "parent_id": "Q739"
     },
@@ -1156,7 +1156,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Vichada"
+        "lang:es": "Vichada"
       },
       "parent_id": "Q739"
     },
@@ -1179,7 +1179,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "La Guajira"
+        "lang:es": "La Guajira"
       },
       "parent_id": "Q739"
     },
@@ -1202,7 +1202,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Guaviare"
+        "lang:es": "Guaviare"
       },
       "parent_id": "Q739"
     },
@@ -1225,7 +1225,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Amazonas"
+        "lang:es": "Amazonas"
       },
       "parent_id": "Q739"
     },
@@ -1248,7 +1248,7 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "Bogotá "
+        "lang:es": "Bogotá "
       },
       "parent_id": "Q739"
     },
@@ -1271,8 +1271,8 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "circunscripcion especial indígena",
-        "lang:en_US": "special constituency for indigenous peoples in Colombia"
+        "lang:es": "circunscripcion especial indígena",
+        "lang:en": "special constituency for indigenous peoples in Colombia"
       },
       "parent_id": "Q739"
     },
@@ -1295,8 +1295,8 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "circunscripción de los Colombianos en el exterior",
-        "lang:en_US": "constituency for Colombians overseas"
+        "lang:es": "circunscripción de los Colombianos en el exterior",
+        "lang:en": "constituency for Colombians overseas"
       },
       "parent_id": "Q739"
     },
@@ -1319,8 +1319,8 @@
         "lang:en": "Constituency of the chamber of representatives of Colombia"
       },
       "name": {
-        "lang:es_LA": "circunscripcion especial para las comunidades afrodescendientes",
-        "lang:en_US": "special constituency for Afro-Colombians"
+        "lang:es": "circunscripcion especial para las comunidades afrodescendientes",
+        "lang:en": "special constituency for Afro-Colombians"
       },
       "parent_id": "Q739"
     },
@@ -1344,8 +1344,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q16491339/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q16491339/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -165,7 +165,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Bolívar"
+        "lang:es": "Bolívar"
       },
       "parent_id": "Q739"
     },
@@ -190,7 +190,7 @@
         "lang:en": "municipality of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cartagena de Indias"
+        "lang:es": "Cartagena de Indias"
       },
       "parent_id": "Q230597"
     },
@@ -214,8 +214,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q18170765/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q18170765/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -76,7 +76,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Antioquia"
+        "lang:es": "Antioquia"
       },
       "parent_id": "Q739"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q21564847/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q21564847/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cesar"
+        "lang:es": "Cesar"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q2398781/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q2398781/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -3779,8 +3779,8 @@
         "lang:en": "Constituency of the Colombian Senate"
       },
       "name": {
-        "lang:es_LA": "circunscripción nacional",
-        "lang:en_US": "national constituency"
+        "lang:es": "circunscripción nacional",
+        "lang:en": "national constituency"
       },
       "parent_id": "Q739"
     },
@@ -3803,8 +3803,8 @@
         "lang:en": "Constituency of the Colombian Senate"
       },
       "name": {
-        "lang:es_LA": "circunscripción especial (indígenas)",
-        "lang:en_US": "special national constituency for indigenous communities"
+        "lang:es": "circunscripción especial (indígenas)",
+        "lang:en": "special national constituency for indigenous communities"
       },
       "parent_id": "Q739"
     },
@@ -3828,8 +3828,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092546/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092546/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Boyacá"
+        "lang:es": "Boyacá"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092547/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092547/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Casanare"
+        "lang:es": "Casanare"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092549/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092549/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Caquetá"
+        "lang:es": "Caquetá"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092550/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092550/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Risaralda"
+        "lang:es": "Risaralda"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092551/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092551/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Quindío"
+        "lang:es": "Quindío"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092552/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092552/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Magdalena"
+        "lang:es": "Magdalena"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092555/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092555/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -76,7 +76,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Nariño"
+        "lang:es": "Nariño"
       },
       "parent_id": "Q739"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092556/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092556/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Arauca"
+        "lang:es": "Arauca"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092558/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092558/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Chocó"
+        "lang:es": "Chocó"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092559/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092559/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -76,7 +76,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Bolívar"
+        "lang:es": "Bolívar"
       },
       "parent_id": "Q739"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092561/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092561/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cauca"
+        "lang:es": "Cauca"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092564/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092564/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Caldas"
+        "lang:es": "Caldas"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092565/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092565/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Atlántico"
+        "lang:es": "Atlántico"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092568/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092568/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -76,7 +76,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Cundinamarca"
+        "lang:es": "Cundinamarca"
       },
       "parent_id": "Q739"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092569/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092569/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Putumayo"
+        "lang:es": "Putumayo"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092570/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092570/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Norte de Santander"
+        "lang:es": "Norte de Santander"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092572/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092572/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Tolima"
+        "lang:es": "Tolima"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092573/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092573/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Vaupés"
+        "lang:es": "Vaupés"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092574/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092574/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Córdoba"
+        "lang:es": "Córdoba"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092577/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092577/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Huila"
+        "lang:es": "Huila"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092579/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092579/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Santander"
+        "lang:es": "Santander"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092582/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092582/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Sucre"
+        "lang:es": "Sucre"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092583/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092583/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Meta"
+        "lang:es": "Meta"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092587/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092587/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Guainía"
+        "lang:es": "Guainía"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092590/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092590/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Archipiélago de San Andrés, Providencia y Santa Catalina"
+        "lang:es": "Archipiélago de San Andrés, Providencia y Santa Catalina"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092593/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092593/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Vichada"
+        "lang:es": "Vichada"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092595/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092595/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Guaviare"
+        "lang:es": "Guaviare"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51092596/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51092596/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Amazonas"
+        "lang:es": "Amazonas"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51093881/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51093881/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -182,7 +182,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Valle del Cauca"
+        "lang:es": "Valle del Cauca"
       },
       "parent_id": "Q739"
     },
@@ -207,7 +207,7 @@
         "lang:en": "municipality of Colombia"
       },
       "name": {
-        "lang:es_LA": "Santiago de Cali"
+        "lang:es": "Santiago de Cali"
       },
       "parent_id": "Q13990"
     },
@@ -231,8 +231,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51094127/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51094127/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -182,7 +182,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Antioquia"
+        "lang:es": "Antioquia"
       },
       "parent_id": "Q739"
     },
@@ -207,7 +207,7 @@
         "lang:en": "municipality of Colombia"
       },
       "name": {
-        "lang:es_LA": "Medellín"
+        "lang:es": "Medellín"
       },
       "parent_id": "Q123304"
     },
@@ -231,8 +231,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q51094137/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q51094137/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -165,7 +165,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Atlántico"
+        "lang:es": "Atlántico"
       },
       "parent_id": "Q739"
     },
@@ -190,7 +190,7 @@
         "lang:en": "municipality of Colombia"
       },
       "name": {
-        "lang:es_LA": "Barranquilla"
+        "lang:es": "Barranquilla"
       },
       "parent_id": "Q230882"
     },
@@ -214,8 +214,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q5260098/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q5260098/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -76,7 +76,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "Valle del Cauca"
+        "lang:es": "Valle del Cauca"
       },
       "parent_id": "Q739"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q5707807/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q5707807/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -27,7 +27,7 @@
         "lang:en": "department of Colombia"
       },
       "name": {
-        "lang:es_LA": "La Guajira"
+        "lang:es": "La Guajira"
       },
       "parent_id": "Q739"
     },
@@ -51,8 +51,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }

--- a/legislative/Q5780806/2018-01-01-to-2018-12-31/popolo-m17n.json
+++ b/legislative/Q5780806/2018-01-01-to-2018-12-31/popolo-m17n.json
@@ -76,7 +76,7 @@
         "lang:en": "capital district or territory"
       },
       "name": {
-        "lang:es_LA": "Bogotá Distrito Capital"
+        "lang:es": "Bogotá Distrito Capital"
       },
       "parent_id": "Q739"
     },
@@ -100,8 +100,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:en_US": "Colombia",
-        "lang:es_LA": "Colombia"
+        "lang:en": "Colombia",
+        "lang:es": "Colombia"
       },
       "parent_id": null
     }


### PR DESCRIPTION
I forgot to update boundaries/index.json with the new language codes when moving to Wikidata codes in bf5cdc2, so this fixes that. Confirmed that none of the old codes are now present in the repo.